### PR TITLE
Refactor task scheduling system to allow for task priorities

### DIFF
--- a/models/task/task.go
+++ b/models/task/task.go
@@ -80,6 +80,9 @@ type Options struct {
 	// If true, duplicate tasks (based on metadata string) will not be added to the queue, and instead the existing
 	// task with matching metadata will be returned. Otherwise, multiple tasks with the same metadata can coexist in the queue.
 	Unique bool
+
+	// Priority indicates the priority of the task in the queue. Higher priority tasks are executed before lower priority ones. Larger numbers indicate higher priority. The default priority is 0.
+	Priority int
 }
 
 // QueueState represents the current state of a task in the queue.
@@ -221,33 +224,6 @@ func (t *Task) Cancel() {
 	// Do not exit task here, so that .Wait() -ing on a task will wait until the task actually exits,
 	// before starting again
 	// t.queueState = Exited
-}
-
-// ClearAndRecompute cancels the task, clears its state, and re-queues it.
-func (t *Task) ClearAndRecompute() {
-	t.Cancel()
-	t.Wait()
-
-	t.exitStatus.Set(TaskNoStatus)
-	t.queueState.Set(Created)
-
-	t.waitChan = make(chan struct{})
-
-	for k := range t.result {
-		delete(t.result, k)
-	}
-
-	if t.err != nil {
-		t.Log().Warn().Msgf("Retrying task that has previous error: %v", t.err)
-		t.err = nil
-	}
-
-	err := t.GetTaskPool().QueueTask(t)
-	if err != nil {
-		return
-	}
-
-	t.GetTaskPool().GetWorkerPool().taskMap[t.taskID] = t
 }
 
 // GetResult returns the task result.

--- a/models/task/task.go
+++ b/models/task/task.go
@@ -70,9 +70,10 @@ type Task struct {
 
 // Priority constants for task scheduling. Higher values run first.
 const (
-	PriorityLow    = 1   // background directory scans
-	PriorityMedium = 2   // file scans — drain ahead of their parent directory scans
-	PriorityHigh   = 999 // user-facing work (uploads, filesystem load)
+	PriorityLow     = 1   // background directory scans
+	PriorityMedium  = 2   // file scans — drain ahead of their parent directory scans
+	PriorityDefault = 3   // jobs registered without an explicit priority — never starved by background scans
+	PriorityHigh    = 999 // user-facing work (uploads, filesystem load)
 )
 
 // Options specifies configuration options for task behavior.
@@ -88,7 +89,7 @@ type Options struct {
 	// task with matching metadata will be returned. Otherwise, multiple tasks with the same metadata can coexist in the queue.
 	Unique bool
 
-	// Priority indicates the priority of the task in the queue. Higher priority tasks are executed before lower priority ones. Larger numbers indicate higher priority. The default priority is 0.
+	// Priority indicates the priority of the task in the queue. Higher priority tasks are executed before lower priority ones. Larger numbers indicate higher priority. Jobs registered without an explicit priority are assigned PriorityDefault.
 	Priority int
 }
 

--- a/models/task/task.go
+++ b/models/task/task.go
@@ -68,6 +68,13 @@ type Task struct {
 	WorkerID int64
 }
 
+// Priority constants for task scheduling. Higher values run first.
+const (
+	PriorityLow    = 1   // background directory scans
+	PriorityMedium = 2   // file scans — drain ahead of their parent directory scans
+	PriorityHigh   = 999 // user-facing work (uploads, filesystem load)
+)
+
 // Options specifies configuration options for task behavior.
 type Options struct {
 	// Persistent indicates whether the task should persist after completion.

--- a/models/task/task.go
+++ b/models/task/task.go
@@ -89,7 +89,8 @@ type Options struct {
 	// task with matching metadata will be returned. Otherwise, multiple tasks with the same metadata can coexist in the queue.
 	Unique bool
 
-	// Priority indicates the priority of the task in the queue. Higher priority tasks are executed before lower priority ones. Larger numbers indicate higher priority. Jobs registered without an explicit priority are assigned PriorityDefault.
+	// Priority indicates the priority of the task in the queue. Higher priority tasks are executed before lower priority ones. Larger numbers indicate higher priority.
+	// 0 is reserved to mean "unspecified": RegisterJob resolves it to PriorityDefault, so a literal priority of 0 cannot be assigned.
 	Priority int
 }
 

--- a/models/task/task_pool.go
+++ b/models/task/task_pool.go
@@ -331,67 +331,6 @@ func (tp *Pool) Cancel() {
 	}
 }
 
-// QueueTask adds a task to this pool for execution.
-func (tp *Pool) QueueTask(tsk *Task) (err error) {
-	select {
-	case <-tp.workerPool.ctx.Done():
-		tp.log.Warn().Msg("Not queuing task while worker pool is going down")
-
-		return err
-	default:
-	}
-
-	if tsk.err != nil {
-		// Tasks that have failed will not be re-tried. If the errored task is removed from the
-		// task map, then it will be re-tried because the previous error was lost. This can be
-		// sometimes be useful, some tasks auto-remove themselves after they finish.
-		tp.log.Warn().Msg("Not re-queuing task that has error set, please restart weblens to try again")
-
-		return err
-	}
-
-	if tsk.taskPool != nil && (tsk.taskPool != tp || tsk.queueState.Load() != Created) {
-		// Task is already queued, we are not allowed to move it to another queue.
-		// We can call .ClearAndRecompute() on the task and it will queue it
-		// again, but it cannot be transferred
-		if tsk.taskPool != tp {
-			tp.log.Warn().Msgf("Attempted to re-queue a [%s] task that is already in a queue", tsk.jobName)
-
-			return err
-		}
-
-		tsk.taskPool.tasks[tsk.taskID] = tsk
-
-		return err
-	}
-
-	if tp.allQueuedFlag.Load() {
-		// We cannot add tasks to a queue that has been closed
-		return wlerrors.WithStack(wlerrors.New("attempting to add task to closed task queue"))
-	}
-
-	// Increment the total task count for this pool and all parent pools
-	tp.IncTaskCount(1)
-
-	// Set the tasks queue
-	tsk.taskPool = tp
-
-	tp.workerPool.lifetimeQueuedCount.Add(1)
-
-	// Put the task in the queue
-	tsk.queueState.Set(InQueue)
-
-	if len(tp.workerPool.retryBuffer) != 0 || len(tp.workerPool.taskStream) == cap(tp.workerPool.taskStream) {
-		tp.workerPool.addToRetryBuffer(tsk)
-	} else {
-		tp.workerPool.taskStream <- tsk
-	}
-
-	tsk.taskPool.tasks[tsk.taskID] = tsk
-
-	return err
-}
-
 // MarkGlobal specifies the work queue as being a "global" one
 func (tp *Pool) MarkGlobal() {
 	tp.treatAsGlobal = true

--- a/models/task/task_test.go
+++ b/models/task/task_test.go
@@ -2,15 +2,38 @@ package task_test
 
 import (
 	"context"
+	"fmt"
+	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/ethanrous/weblens/models/task"
+	context_mod "github.com/ethanrous/weblens/modules/wlcontext"
 	"github.com/ethanrous/weblens/modules/wlerrors"
 	"github.com/ethanrous/weblens/modules/wlog"
 	"github.com/stretchr/testify/assert"
 )
+
+// uniqueMeta is a task.Metadata whose MetaString is unique per instance, so
+// every dispatched task gets a distinct task ID and actually lands in the queue
+// (rather than collapsing onto an existing task ID).
+type uniqueMeta struct {
+	jobName  string
+	uniqueID string
+}
+
+func (m uniqueMeta) JobName() string             { return m.jobName }
+func (m uniqueMeta) MetaString() string          { return m.jobName + ":" + m.uniqueID }
+func (m uniqueMeta) FormatToResult() task.Result { return task.Result{} }
+func (m uniqueMeta) Verify() error               { return nil }
+
+var uniqueMetaCounter atomic.Int64
+
+func newUniqueMeta(jobName string) task.Metadata {
+	return uniqueMeta{jobName: jobName, uniqueID: fmt.Sprintf("%d", uniqueMetaCounter.Add(1))}
+}
 
 var intentionalFailure = wlerrors.Errorf("intentional failure for testing")
 
@@ -850,19 +873,6 @@ func TestWorkerPool_DispatchJob(t *testing.T) {
 	})
 }
 
-func TestWorkerPool_Status(t *testing.T) {
-	t.Run("returns status values", func(t *testing.T) {
-		wp := task.NewTestWorkerPool(2)
-
-		queueLen, total, busy, alive, retry := wp.Status()
-		assert.GreaterOrEqual(t, queueLen, 0)
-		assert.GreaterOrEqual(t, total, 0)
-		assert.GreaterOrEqual(t, busy, 0)
-		assert.GreaterOrEqual(t, alive, 0)
-		assert.GreaterOrEqual(t, retry, 0)
-	})
-}
-
 func TestWorkerPool_GetTask(t *testing.T) {
 	t.Run("returns nil for non-existent task", func(t *testing.T) {
 		wp := task.NewTestWorkerPool(1)
@@ -929,20 +939,6 @@ func TestWorkerPool_ConcurrentAccess(t *testing.T) {
 
 			seen[pool.ID()] = true
 		}
-	})
-
-	t.Run("handles concurrent status reads", func(_ *testing.T) {
-		wp := task.NewTestWorkerPool(1)
-
-		var wg sync.WaitGroup
-
-		for range 100 {
-			wg.Go(func() {
-				_, _, _, _, _ = wp.Status()
-			})
-		}
-
-		wg.Wait()
 	})
 
 	t.Run("handles concurrent job registration", func(_ *testing.T) {
@@ -1966,6 +1962,218 @@ func TestPool_GetRootPool_NestedPools(t *testing.T) {
 		if grandchildPool != nil {
 			root := grandchildPool.GetRootPool()
 			assert.NotNil(t, root)
+		}
+	})
+}
+
+// ==================== Scheduler Concurrency Tests ====================
+
+func TestWorkerPool_ConcurrentDispatchQueueRace(t *testing.T) {
+	t.Run("concurrent dispatch races scheduler drain on taskQueue", func(t *testing.T) {
+		wp := task.NewTestWorkerPool(4)
+		wp.Run(task.NewTestContext())
+
+		wp.RegisterJob("race-job", func(_ *task.Task) {})
+
+		var wg sync.WaitGroup
+
+		for range 8 {
+			wg.Go(func() {
+				for range 200 {
+					meta := newUniqueMeta("race-job")
+
+					_, err := wp.DispatchJob(context.Background(), "race-job", meta, nil)
+					assert.NoError(t, err)
+				}
+			})
+		}
+
+		wg.Wait()
+	})
+}
+
+func TestWorkerPool_SchedulerCanceledTaskUnlock(t *testing.T) {
+	t.Run("scheduler does not panic when last queued task is canceled", func(t *testing.T) {
+		wp := task.NewTestWorkerPool(1)
+		wp.Run(task.NewTestContext())
+
+		release := make(chan struct{})
+
+		// A blocking handler keeps the single worker busy so dispatched tasks
+		// pile up in the queue, letting the scheduler pop tasks whose context
+		// has already been canceled.
+		wp.RegisterJob("blocker-job", func(tsk *task.Task) {
+			select {
+			case <-release:
+			case <-tsk.Ctx.Done():
+			}
+		})
+
+		// Saturate the worker and the taskStream buffer.
+		for range 4 {
+			meta := newUniqueMeta("blocker-job")
+			_, err := wp.DispatchJob(context.Background(), "blocker-job", meta, nil)
+			assert.NoError(t, err)
+		}
+
+		// Repeatedly dispatch a task and cancel it immediately so the scheduler
+		// hits the canceled branch in taskScheduler.
+		for range 2000 {
+			meta := newUniqueMeta("blocker-job")
+
+			tsk, err := wp.DispatchJob(context.Background(), "blocker-job", meta, nil)
+			assert.NoError(t, err)
+
+			tsk.Cancel()
+		}
+
+		// Give the scheduler time to drain (and panic if the bug is present).
+		time.Sleep(200 * time.Millisecond)
+
+		close(release)
+	})
+}
+
+func TestWorkerPool_PriorityScheduling(t *testing.T) {
+	t.Run("higher priority tasks execute before lower priority tasks", func(t *testing.T) {
+		wp := task.NewTestWorkerPool(1)
+		wp.Run(task.NewTestContext())
+
+		gateStarted := make(chan struct{})
+		release := make(chan struct{})
+
+		var orderMu sync.Mutex
+
+		var order []string
+
+		record := func(tsk *task.Task) {
+			orderMu.Lock()
+			defer orderMu.Unlock()
+
+			order = append(order, tsk.ID())
+		}
+
+		wp.RegisterJob("gate-job", func(_ *task.Task) {
+			close(gateStarted)
+			<-release
+		})
+		wp.RegisterJob("filler-job", record, task.Options{Priority: 1})
+		wp.RegisterJob("low-job", record, task.Options{Priority: 1})
+		wp.RegisterJob("high-job", record, task.Options{Priority: 2})
+
+		// Occupy the single worker so subsequent tasks accumulate in the queue.
+		gate, err := wp.DispatchJob(context.Background(), "gate-job", newUniqueMeta("gate-job"), nil)
+		assert.NoError(t, err)
+
+		<-gateStarted
+
+		// Fill the taskStream buffer (2 slots) and the scheduler's in-hand slot,
+		// so everything dispatched below stays in the priority queue until release.
+		fillers := make([]*task.Task, 0, 3)
+
+		for range 3 {
+			tsk, err := wp.DispatchJob(context.Background(), "filler-job", newUniqueMeta("filler-job"), nil)
+			assert.NoError(t, err)
+
+			fillers = append(fillers, tsk)
+		}
+
+		lows := make([]*task.Task, 0, 3)
+
+		for range 3 {
+			tsk, err := wp.DispatchJob(context.Background(), "low-job", newUniqueMeta("low-job"), nil)
+			assert.NoError(t, err)
+
+			lows = append(lows, tsk)
+		}
+
+		highs := make([]*task.Task, 0, 3)
+
+		for range 3 {
+			tsk, err := wp.DispatchJob(context.Background(), "high-job", newUniqueMeta("high-job"), nil)
+			assert.NoError(t, err)
+
+			highs = append(highs, tsk)
+		}
+
+		close(release)
+
+		gate.Wait()
+
+		for _, tsk := range slices.Concat(fillers, lows, highs) {
+			tsk.Wait()
+		}
+
+		// Every high-priority task must execute before every low-priority task.
+		for _, h := range highs {
+			for _, l := range lows {
+				assert.Less(t, slices.Index(order, h.ID()), slices.Index(order, l.ID()))
+			}
+		}
+
+		// Equal-priority tasks keep FIFO order.
+		for i := range len(highs) - 1 {
+			assert.Less(t, slices.Index(order, highs[i].ID()), slices.Index(order, highs[i+1].ID()))
+		}
+
+		for i := range len(lows) - 1 {
+			assert.Less(t, slices.Index(order, lows[i].ID()), slices.Index(order, lows[i+1].ID()))
+		}
+	})
+}
+
+func TestWorkerPool_SchedulerShutdown(t *testing.T) {
+	t.Run("scheduler exits when canceled while blocked sending to task stream", func(t *testing.T) {
+		ctx, cancel := task.NewTestContextWithCancel()
+
+		wp := task.NewTestWorkerPool(1)
+		wp.Run(ctx)
+
+		started := make(chan struct{}, 4)
+		release := make(chan struct{})
+
+		wp.RegisterJob("blocking-job", func(_ *task.Task) {
+			started <- struct{}{}
+
+			<-release
+		})
+
+		// Occupy the single worker.
+		_, err := wp.DispatchJob(context.Background(), "blocking-job", newUniqueMeta("blocking-job"), nil)
+		assert.NoError(t, err)
+
+		<-started
+
+		// Fill the taskStream buffer (2 slots) plus one more so the scheduler
+		// blocks sending to the full stream.
+		for range 3 {
+			_, err := wp.DispatchJob(context.Background(), "blocking-job", newUniqueMeta("blocking-job"), nil)
+			assert.NoError(t, err)
+		}
+
+		// Give the scheduler time to reach the blocked send.
+		time.Sleep(100 * time.Millisecond)
+
+		cancel()
+
+		// Let the in-flight task finish; the worker then exits without draining
+		// the stream because the pool context is canceled.
+		close(release)
+
+		wg, ok := ctx.Value(context_mod.WgKey).(*sync.WaitGroup)
+		assert.True(t, ok)
+
+		done := make(chan struct{})
+
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("worker pool did not shut down cleanly; scheduler is likely blocked sending to the task stream")
 		}
 	})
 }

--- a/models/task/task_test.go
+++ b/models/task/task_test.go
@@ -2120,6 +2120,101 @@ func TestWorkerPool_PriorityScheduling(t *testing.T) {
 			assert.Less(t, slices.Index(order, lows[i].ID()), slices.Index(order, lows[i+1].ID()))
 		}
 	})
+
+	t.Run("jobs registered without a priority schedule ahead of background scan priorities", func(t *testing.T) {
+		wp := task.NewTestWorkerPool(1)
+		wp.Run(task.NewTestContext())
+
+		gateStarted := make(chan struct{})
+		release := make(chan struct{})
+
+		var orderMu sync.Mutex
+
+		var order []string
+
+		record := func(tsk *task.Task) {
+			orderMu.Lock()
+			defer orderMu.Unlock()
+
+			order = append(order, tsk.ID())
+		}
+
+		wp.RegisterJob("gate-job", func(_ *task.Task) {
+			close(gateStarted)
+			<-release
+		})
+		wp.RegisterJob("filler-job", record, task.Options{Priority: task.PriorityLow})
+		wp.RegisterJob("background-job", record, task.Options{Priority: task.PriorityMedium})
+		wp.RegisterJob("default-job", record)
+		wp.RegisterJob("high-job", record, task.Options{Priority: task.PriorityHigh})
+
+		// Occupy the single worker so subsequent tasks accumulate in the queue.
+		gate, err := wp.DispatchJob(context.Background(), "gate-job", newUniqueMeta("gate-job"), nil)
+		assert.NoError(t, err)
+
+		<-gateStarted
+
+		// Fill the taskStream buffer (2 slots) and the scheduler's in-hand slot,
+		// so everything dispatched below stays in the priority queue until release.
+		fillers := make([]*task.Task, 0, 3)
+
+		for range 3 {
+			tsk, err := wp.DispatchJob(context.Background(), "filler-job", newUniqueMeta("filler-job"), nil)
+			assert.NoError(t, err)
+
+			fillers = append(fillers, tsk)
+		}
+
+		backgrounds := make([]*task.Task, 0, 3)
+
+		for range 3 {
+			tsk, err := wp.DispatchJob(context.Background(), "background-job", newUniqueMeta("background-job"), nil)
+			assert.NoError(t, err)
+
+			backgrounds = append(backgrounds, tsk)
+		}
+
+		defaults := make([]*task.Task, 0, 3)
+
+		for range 3 {
+			tsk, err := wp.DispatchJob(context.Background(), "default-job", newUniqueMeta("default-job"), nil)
+			assert.NoError(t, err)
+
+			defaults = append(defaults, tsk)
+		}
+
+		highs := make([]*task.Task, 0, 3)
+
+		for range 3 {
+			tsk, err := wp.DispatchJob(context.Background(), "high-job", newUniqueMeta("high-job"), nil)
+			assert.NoError(t, err)
+
+			highs = append(highs, tsk)
+		}
+
+		close(release)
+
+		gate.Wait()
+
+		for _, tsk := range slices.Concat(fillers, backgrounds, defaults, highs) {
+			tsk.Wait()
+		}
+
+		// High-priority tasks execute before default-priority tasks.
+		for _, h := range highs {
+			for _, d := range defaults {
+				assert.Less(t, slices.Index(order, h.ID()), slices.Index(order, d.ID()))
+			}
+		}
+
+		// Default-priority tasks execute before background scan-priority tasks,
+		// even though the background tasks were dispatched first.
+		for _, d := range defaults {
+			for _, b := range backgrounds {
+				assert.Less(t, slices.Index(order, d.ID()), slices.Index(order, b.ID()))
+			}
+		}
+	})
 }
 
 func TestWorkerPool_SchedulerShutdown(t *testing.T) {

--- a/models/task/task_test.go
+++ b/models/task/task_test.go
@@ -2143,7 +2143,10 @@ func TestWorkerPool_PriorityScheduling(t *testing.T) {
 			close(gateStarted)
 			<-release
 		})
-		wp.RegisterJob("filler-job", record, task.Options{Priority: task.PriorityLow})
+		// Fillers run at PriorityHigh so they are always the three tasks committed to
+		// the taskStream buffer and the scheduler's in-hand slot, even when the
+		// scheduler drains the queue slower than the dispatch loop below runs.
+		wp.RegisterJob("filler-job", record, task.Options{Priority: task.PriorityHigh})
 		wp.RegisterJob("background-job", record, task.Options{Priority: task.PriorityMedium})
 		wp.RegisterJob("default-job", record)
 		wp.RegisterJob("high-job", record, task.Options{Priority: task.PriorityHigh})

--- a/models/task/worker_pool.go
+++ b/models/task/worker_pool.go
@@ -12,6 +12,7 @@ import (
 	context_mod "github.com/ethanrous/weblens/modules/wlcontext"
 	"github.com/ethanrous/weblens/modules/wlerrors"
 	"github.com/ethanrous/weblens/modules/wlog"
+	"github.com/ethanrous/weblens/modules/wlslices"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 )
@@ -37,6 +38,7 @@ type hit struct {
 }
 
 type workChannel chan *Task
+type workQueue []*Task
 type hitChannel chan hit
 
 type job struct {
@@ -53,27 +55,37 @@ type WorkerPool struct {
 
 	busyCount *atomic.Int64 // Number of workers currently executing a task
 
+	// registeredJobs holds the templates for all registered jobs that can be dispatched in this worker pool, indexed by job name.
 	registeredJobs map[string]job
+	jobsMu         sync.RWMutex
 
+	// The taskMap holds a reference to every task that has been queued in this worker pool, indexed by task ID.
+	// This allows for quick retrieval of any task by ID, and also serves as a master list of
+	// all tasks for status reporting and management purposes.
 	taskMap map[string]*Task
+	taskMu  sync.RWMutex
 
+	// The taskPoolMap holds a reference to every task pool that has been created in this worker pool, indexed by task pool ID.
 	taskPoolMap map[string]*Pool
+	taskPoolMu  sync.Mutex
 
+	// The taskStream is the channel that workers pull tasks from to execute. Tasks are added to the taskStream by the task scheduler.
 	taskStream workChannel
 	hitStream  hitChannel
 
-	retryBuffer    []*Task
+	// The taskQueue is the list of tasks that are waiting to be executed.
+	// Tasks are pulled from the queue and added to the taskStream by the task scheduler.
+	// The taskQueue is sorted by task priority.
+	taskQueue   workQueue
+	taskQueueMu sync.RWMutex
+
+	// The schedulerNotifier is used to wake up the task scheduler when new tasks are added to the taskQueue.
+	schedulerNotifier chan struct{}
+
 	maxWorkers     atomic.Int64 // Max allowed worker count
 	currentWorkers atomic.Int64 // Current total of workers on the pool
 
-	lifetimeQueuedCount atomic.Int64
-
-	jobsMu sync.RWMutex
-
-	taskMu sync.RWMutex
-
-	taskPoolMu   sync.Mutex
-	taskBufferMu sync.Mutex
+	lifetimeQueuedCount atomic.Int64 // Total count of tasks that have been queued on this worker pool since it was created
 }
 
 // NewWorkerPool creates and initializes a new worker pool with the specified number of workers.
@@ -89,8 +101,10 @@ func NewWorkerPool(initWorkers int) *WorkerPool {
 
 		busyCount: &atomic.Int64{},
 
-		taskStream:  make(workChannel, initWorkers*1000),
-		retryBuffer: []*Task{},
+		taskQueue:  []*Task{},
+		taskStream: make(workChannel, initWorkers*2),
+
+		schedulerNotifier: make(chan struct{}, 1),
 
 		hitStream: make(hitChannel, initWorkers*2),
 	}
@@ -145,17 +159,6 @@ func (wp *WorkerPool) NewTaskPool(replace bool, createdBy *Task) (*Pool, error) 
 	}
 
 	return tp, nil
-}
-
-// Status returns the count of tasks in the queue, the total number of tasks accepted,
-// number of busy workers, and the total number of live workers in the worker pool
-func (wp *WorkerPool) Status() (int, int, int, int, int) {
-	total := int(wp.lifetimeQueuedCount.Load())
-
-	wp.taskBufferMu.Lock()
-	defer wp.taskBufferMu.Unlock()
-
-	return len(wp.taskStream), total, int(wp.busyCount.Load()), int(wp.currentWorkers.Load()), len(wp.retryBuffer)
 }
 
 // GetTaskPool returns the task pool with the specified ID.
@@ -278,8 +281,6 @@ func (wp *WorkerPool) DispatchJob(ctx context.Context, jobName string, meta Meta
 		cancelFunc: cancel,
 	}
 
-	wp.addTask(t)
-
 	t.Log().Trace().Stack().Msgf("Task [%s] created", taskID)
 
 	select {
@@ -315,26 +316,7 @@ func (wp *WorkerPool) DispatchJob(ctx context.Context, jobName string, meta Meta
 		return nil, wlerrors.Errorf("attempting to add task [%s] to closed task queue [pool created by %s]", t.JobName(), pool.ID())
 	}
 
-	// Inc the task count for the pool and all parent pools.
-	pool.IncTaskCount(1)
-
-	// Set the tasks queue
-	t.setTaskPoolInternal(pool)
-
-	wp.lifetimeQueuedCount.Add(1)
-
-	// Put the task in the queue
-	t.queueState.Set(InQueue)
-
-	if len(wp.retryBuffer) != 0 || len(wp.taskStream) == cap(wp.taskStream) {
-		wp.addToRetryBuffer(t)
-	} else {
-		wp.taskStream <- t
-	}
-
-	t.QueueTime.Set(time.Now())
-
-	pool.addTask(t)
+	wp.queueTask(t, pool)
 
 	return t, nil
 }
@@ -359,7 +341,7 @@ func (wp *WorkerPool) Run(ctx context.Context) {
 	go wp.reaper(ctx)
 
 	// Spawn the buffer worker
-	go wp.bufferDrainer(ctx)
+	go wp.taskScheduler(ctx)
 
 	// Spawn the status printer
 	// go wp.statusReporter(ctx)
@@ -388,11 +370,62 @@ func (wp *WorkerPool) GetTasks() []*Task {
 	return slices.Collect(maps.Values(wp.taskMap))
 }
 
-func (wp *WorkerPool) addTask(task *Task) {
+func (wp *WorkerPool) getJobPriority(jobName string) (int, error) {
+	wp.jobsMu.RLock()
+	defer wp.jobsMu.RUnlock()
+
+	job, ok := wp.registeredJobs[jobName]
+	if !ok {
+		return 0, wlerrors.Errorf("job [%s] not registered", jobName)
+
+	}
+
+	return job.opts.Priority, nil
+}
+
+func (wp *WorkerPool) queueTask(t *Task, pool *Pool) {
 	wp.taskMu.Lock()
 	defer wp.taskMu.Unlock()
 
-	wp.taskMap[task.ID()] = task
+	wp.taskMap[t.ID()] = t
+
+	// Inc the task count for the pool and all parent pools.
+	pool.IncTaskCount(1)
+
+	// Set the tasks queue
+	t.setTaskPoolInternal(pool)
+
+	wp.lifetimeQueuedCount.Add(1)
+
+	// Put the task in the queue
+	t.queueState.Set(InQueue)
+
+	// Add task to queue in sorted order by priority (higher priority tasks should be closer to the front of the queue)
+	wp.taskQueue = wlslices.InsertFunc(wp.taskQueue, t, func(t1, t2 *Task) int {
+		p1, err := wp.getJobPriority(t1.JobName())
+		if err != nil {
+			p1 = 0
+		}
+
+		p2, err := wp.getJobPriority(t2.JobName())
+		if err != nil {
+			p2 = 0
+		}
+
+		return p2 - p1
+	})
+
+	// Add the task to the task pool
+	pool.addTask(t)
+
+	// Set the time the task was added to the queue, this is used for status reporting and timeout checks
+	t.QueueTime.Set(time.Now())
+
+	// Finally, notify the scheduler that a new task has been added to the queue
+	select {
+	case wp.schedulerNotifier <- struct{}{}:
+	default:
+	}
 }
 
 func (wp *WorkerPool) removeTask(taskID string) {
@@ -460,7 +493,7 @@ func (wp *WorkerPool) execWorker(workerCtx context.Context, isReplacement bool) 
 					select {
 					case <-t.Ctx.Done():
 						// Task was canceled, do not run it
-						wlog.FromContext(t.Ctx).Trace().Msgf("Task was canceled while in queue, not running")
+						wlog.FromContext(t.Ctx).Trace().Msgf("Task was canceled before execution, skipping")
 
 						continue
 					default:
@@ -471,30 +504,6 @@ func (wp *WorkerPool) execWorker(workerCtx context.Context, isReplacement bool) 
 						wlog.FromContext(t.Ctx).Trace().Str("exit_status", string(t.exitStatus.Load())).Msgf("Task already has exit status, not running")
 
 						continue
-					}
-
-					// Replacement workers are not allowed to do "scan_directory" tasks
-					// TODO: - generalize
-					if isReplacement && t.jobName == "scan_directory" && t.exitStatus.Load() == TaskNoStatus {
-						// If there are twice the number of free spaces in the chan, don't bother pulling
-						// everything into the waiting buffer, just put it at the end right now.
-						if cap(wp.taskStream)-len(wp.taskStream) > int(wp.currentWorkers.Load())*2 {
-							wp.taskStream <- t
-
-							continue
-						}
-
-						tBuf := []*Task{t}
-
-						for t = range wp.taskStream {
-							if t.jobName == "scan_directory" {
-								tBuf = append(tBuf, t)
-							} else {
-								break
-							}
-						}
-
-						wp.addToRetryBuffer(tBuf...)
 					}
 
 					newl := wlog.FromContext(t.Ctx).With().
@@ -713,36 +722,7 @@ func (wp *WorkerPool) reaper(ctx context.Context) {
 	}
 }
 
-// func (wp *WorkerPool) statusReporter(ctx context.Context) {
-// 	var lastCount int
-//
-// 	ticker := time.NewTicker(time.Second * 10)
-//
-// 	defer func() {
-// 		log.FromContext(ctx).Debug().Msg("status reporter exiting")
-// 	}()
-//
-// 	for {
-// 		select {
-// 		case _, ok := <-ctx.Done():
-// 			if !ok {
-// 				return
-// 			}
-// 		case <-ticker.C:
-// 			remaining, total, busy, alive, retrySize := wp.Status()
-// 			if lastCount != remaining || busy != 0 {
-// 				lastCount = remaining
-// 				log.FromContext(ctx).Debug().Int("queue_remaining", remaining).Int("queue_total", total).Int("queue_buffered", retrySize).Int("busy_workers", busy).Int("alive_workers", alive).Msgf(
-// 					"Worker pool status - %d tasks in queue, %d total tasks queued, %d busy workers, %d alive workers", remaining, total, busy, alive,
-// 				)
-// 			}
-// 		}
-// 	}
-// }
-
-func (wp *WorkerPool) bufferDrainer(ctx context.Context) {
-	ticker := time.NewTicker(time.Second * 10)
-
+func (wp *WorkerPool) taskScheduler(ctx context.Context) {
 	defer func() {
 		wlog.FromContext(ctx).Debug().Msg("buffer drainer exiting")
 	}()
@@ -755,27 +735,29 @@ func (wp *WorkerPool) bufferDrainer(ctx context.Context) {
 			}
 
 			wlog.FromContext(ctx).Warn().Msg("buffer drainer not exiting?")
-		case <-ticker.C:
-			wp.taskBufferMu.Lock()
+		case <-wp.schedulerNotifier:
+			// When we get a notification that tasks have been added to the queue, we drain the queue.
+			wp.taskQueueMu.Lock()
+			for len(wp.taskQueue) != 0 {
+				// Pop the first task off and schedule it.
+				t := wp.taskQueue[0]
+				wp.taskQueue = wp.taskQueue[1:]
 
-			if len(wp.retryBuffer) != 0 && len(wp.taskStream) == 0 {
-				for _, t := range wp.retryBuffer {
-					wp.taskStream <- t
+				select {
+				case <-t.Ctx.Done():
+					// Task was canceled, do not run it
+					wlog.FromContext(t.Ctx).Trace().Msgf("Task was canceled while in queue, not running")
+
+					continue
+				default:
 				}
 
-				wp.retryBuffer = []*Task{}
+				wp.taskStream <- t
 			}
 
-			wp.taskBufferMu.Unlock()
+			wp.taskQueueMu.Unlock()
 		}
 	}
-}
-
-func (wp *WorkerPool) addToRetryBuffer(tasks ...*Task) {
-	wp.taskBufferMu.Lock()
-	defer wp.taskBufferMu.Unlock()
-
-	wp.retryBuffer = append(wp.retryBuffer, tasks...)
 }
 
 func (wp *WorkerPool) getRegisteredJob(jobName string) job {

--- a/models/task/worker_pool.go
+++ b/models/task/worker_pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"maps"
 	"slices"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -12,7 +13,6 @@ import (
 	context_mod "github.com/ethanrous/weblens/modules/wlcontext"
 	"github.com/ethanrous/weblens/modules/wlerrors"
 	"github.com/ethanrous/weblens/modules/wlog"
-	"github.com/ethanrous/weblens/modules/wlslices"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 )
@@ -390,22 +390,20 @@ func (wp *WorkerPool) queueTask(t *Task, pool *Pool) {
 	// Put the task in the queue
 	t.queueState.Set(InQueue)
 
-	// Add task to queue in sorted order by priority (higher priority tasks should be closer to the front of the queue)
-	wp.taskQueueMu.Lock()
-	wp.taskQueue = wlslices.InsertFunc(wp.taskQueue, t, func(a, b *Task) int {
-		if a.work.opts.Priority == b.work.opts.Priority {
-			return -1 // tie: keep FIFO — new task goes after existing equal-priority tasks
-		}
+	// Set the queue time before the task becomes visible to the scheduler; it is used for status reporting and timeout checks
+	t.QueueTime.Set(time.Now())
 
-		return b.work.opts.Priority - a.work.opts.Priority
+	// Add task to queue in sorted order by priority (higher priority tasks should be closer to the front of the queue).
+	// Upper-bound insert: after all tasks with priority >= ours, so equal-priority tasks keep FIFO order.
+	wp.taskQueueMu.Lock()
+	i := sort.Search(len(wp.taskQueue), func(i int) bool {
+		return wp.taskQueue[i].work.opts.Priority < t.work.opts.Priority
 	})
+	wp.taskQueue = slices.Insert(wp.taskQueue, i, t)
 	wp.taskQueueMu.Unlock()
 
 	// Add the task to the task pool
 	pool.addTask(t)
-
-	// Set the time the task was added to the queue, this is used for status reporting and timeout checks
-	t.QueueTime.Set(time.Now())
 
 	// Finally, notify the scheduler that a new task has been added to the queue
 	select {

--- a/models/task/worker_pool.go
+++ b/models/task/worker_pool.go
@@ -736,6 +736,7 @@ func (wp *WorkerPool) taskScheduler(ctx context.Context) {
 			for len(wp.taskQueue) != 0 {
 				// Pop the first task off and schedule it.
 				t := wp.taskQueue[0]
+				wp.taskQueue[0] = nil
 				wp.taskQueue = wp.taskQueue[1:]
 
 				wp.taskQueueMu.Unlock()

--- a/models/task/worker_pool.go
+++ b/models/task/worker_pool.go
@@ -299,9 +299,7 @@ func (wp *WorkerPool) DispatchJob(ctx context.Context, jobName string, meta Meta
 	}
 
 	if t.taskPool != nil && (t.taskPool != pool || t.queueState.Load() != Created) {
-		// Task is already queued, we are not allowed to move it to another queue.
-		// We can call .ClearAndRecompute() on the task and it will queue it
-		// again, but it cannot be transferred
+		// Task is already queued; it cannot be transferred to another queue.
 		if t.taskPool != pool {
 			return nil, wlerrors.Errorf("Attempted to re-queue a [%s] task that is already in another queue", t.jobName)
 		}
@@ -370,24 +368,10 @@ func (wp *WorkerPool) GetTasks() []*Task {
 	return slices.Collect(maps.Values(wp.taskMap))
 }
 
-func (wp *WorkerPool) getJobPriority(jobName string) (int, error) {
-	wp.jobsMu.RLock()
-	defer wp.jobsMu.RUnlock()
-
-	job, ok := wp.registeredJobs[jobName]
-	if !ok {
-		return 0, wlerrors.Errorf("job [%s] not registered", jobName)
-
-	}
-
-	return job.opts.Priority, nil
-}
-
 func (wp *WorkerPool) queueTask(t *Task, pool *Pool) {
 	wp.taskMu.Lock()
-	defer wp.taskMu.Unlock()
-
 	wp.taskMap[t.ID()] = t
+	wp.taskMu.Unlock()
 
 	// Inc the task count for the pool and all parent pools.
 	pool.IncTaskCount(1)
@@ -401,19 +385,15 @@ func (wp *WorkerPool) queueTask(t *Task, pool *Pool) {
 	t.queueState.Set(InQueue)
 
 	// Add task to queue in sorted order by priority (higher priority tasks should be closer to the front of the queue)
-	wp.taskQueue = wlslices.InsertFunc(wp.taskQueue, t, func(t1, t2 *Task) int {
-		p1, err := wp.getJobPriority(t1.JobName())
-		if err != nil {
-			p1 = 0
+	wp.taskQueueMu.Lock()
+	wp.taskQueue = wlslices.InsertFunc(wp.taskQueue, t, func(a, b *Task) int {
+		if a.work.opts.Priority == b.work.opts.Priority {
+			return -1 // tie: keep FIFO — new task goes after existing equal-priority tasks
 		}
 
-		p2, err := wp.getJobPriority(t2.JobName())
-		if err != nil {
-			p2 = 0
-		}
-
-		return p2 - p1
+		return b.work.opts.Priority - a.work.opts.Priority
 	})
+	wp.taskQueueMu.Unlock()
 
 	// Add the task to the task pool
 	pool.addTask(t)
@@ -647,9 +627,10 @@ e.g. all n `wp.maxWorkers` are "scan_directory" tasks parked and waiting
 for their "scan_file" children tasks to complete, but never will since
 all worker threads are taken up by blocked tasks.
 
-Replacement workers:
-1. Are not allowed to pick up "scan_directory" tasks
-2. will exit once the main thread has woken up, and shrunk the worker pool back down
+Replacement workers exit once the main thread has woken up and shrunk the
+worker pool back down. Task priority (see Options.Priority) keeps child
+tasks ahead of their parents in the queue, so a parked parent's children
+are scheduled first.
 */
 func (wp *WorkerPool) addReplacementWorker(ctx context.Context) {
 	wp.maxWorkers.Add(1)
@@ -723,8 +704,20 @@ func (wp *WorkerPool) reaper(ctx context.Context) {
 }
 
 func (wp *WorkerPool) taskScheduler(ctx context.Context) {
+	err := context_mod.AddToWg(ctx)
+	if err != nil {
+		wlog.FromContext(ctx).Error().Stack().Err(err).Msg("Failed to add task scheduler to wait group")
+
+		return
+	}
+
 	defer func() {
-		wlog.FromContext(ctx).Debug().Msg("buffer drainer exiting")
+		err = context_mod.WgDone(ctx)
+		if err != nil {
+			wlog.FromContext(ctx).Error().Stack().Err(err).Msg("Failed to remove task scheduler from wait group")
+		}
+
+		wlog.FromContext(ctx).Debug().Msg("task scheduler exiting")
 	}()
 
 	for {
@@ -734,7 +727,7 @@ func (wp *WorkerPool) taskScheduler(ctx context.Context) {
 				return
 			}
 
-			wlog.FromContext(ctx).Warn().Msg("buffer drainer not exiting?")
+			wlog.FromContext(ctx).Warn().Msg("task scheduler not exiting?")
 		case <-wp.schedulerNotifier:
 			// When we get a notification that tasks have been added to the queue, we drain the queue.
 			wp.taskQueueMu.Lock()
@@ -743,16 +736,28 @@ func (wp *WorkerPool) taskScheduler(ctx context.Context) {
 				t := wp.taskQueue[0]
 				wp.taskQueue = wp.taskQueue[1:]
 
+				wp.taskQueueMu.Unlock()
+
 				select {
 				case <-t.Ctx.Done():
 					// Task was canceled, do not run it
 					wlog.FromContext(t.Ctx).Trace().Msgf("Task was canceled while in queue, not running")
 
+					wp.taskQueueMu.Lock()
+
 					continue
 				default:
 				}
 
-				wp.taskStream <- t
+				// Send must remain cancellable so a full taskStream cannot block
+				// the scheduler forever during shutdown.
+				select {
+				case wp.taskStream <- t:
+				case <-ctx.Done():
+					return
+				}
+
+				wp.taskQueueMu.Lock()
 			}
 
 			wp.taskQueueMu.Unlock()

--- a/models/task/worker_pool.go
+++ b/models/task/worker_pool.go
@@ -209,6 +209,12 @@ func (wp *WorkerPool) RegisterJob(jobName string, fn HandlerFunc, opts ...Option
 		o = opts[0]
 	}
 
+	// Every job must have a real priority; an unset priority resolves to the
+	// default so it is never scheduled behind background scan work.
+	if o.Priority == 0 {
+		o.Priority = PriorityDefault
+	}
+
 	wp.registeredJobs[jobName] = job{handler: fn, opts: o}
 }
 

--- a/models/task/worker_pool.go
+++ b/models/task/worker_pool.go
@@ -633,10 +633,8 @@ e.g. all n `wp.maxWorkers` are "scan_directory" tasks parked and waiting
 for their "scan_file" children tasks to complete, but never will since
 all worker threads are taken up by blocked tasks.
 
-Replacement workers exit once the main thread has woken up and shrunk the
-worker pool back down. Task priority (see Options.Priority) keeps child
-tasks ahead of their parents in the queue, so a parked parent's children
-are scheduled first.
+Replacement workers exit, typically, once the main thread has woken up and shrunk the
+worker pool back down.
 */
 func (wp *WorkerPool) addReplacementWorker(ctx context.Context) {
 	wp.maxWorkers.Add(1)

--- a/services/jobs/jobs.go
+++ b/services/jobs/jobs.go
@@ -90,14 +90,14 @@ func GatherFilesystemStats(tsk *task.Task) {
 
 // RegisterJobs registers all available job handlers with the worker pool.
 func RegisterJobs(workerPool *task.WorkerPool) {
-	workerPool.RegisterJob(job_model.ScanDirectoryTask, ScanDirectory)
-	workerPool.RegisterJob(job_model.ScanFileTask, ScanFile)
-	workerPool.RegisterJob(job_model.UploadFilesTask, HandleFileUploads, task.Options{Persistent: true, Unique: true})
+	workerPool.RegisterJob(job_model.ScanDirectoryTask, ScanDirectory, task.Options{Priority: 1})
+	workerPool.RegisterJob(job_model.ScanFileTask, ScanFile, task.Options{Priority: 2})
+	workerPool.RegisterJob(job_model.UploadFilesTask, HandleFileUploads, task.Options{Persistent: true, Unique: true, Priority: 999})
 	workerPool.RegisterJob(job_model.CreateZipTask, CreateZip, task.Options{Persistent: true, Unique: false})
 	workerPool.RegisterJob(job_model.GatherFsStatsTask, GatherFilesystemStats)
 	workerPool.RegisterJob(job_model.BackupTask, DoBackup)
 	workerPool.RegisterJob(job_model.CopyFileFromCoreTask, CopyFileFromCore)
 	workerPool.RegisterJob(job_model.RestoreCoreTask, RestoreCore)
-	workerPool.RegisterJob(job_model.LoadFilesystemTask, LoadAtPath)
+	workerPool.RegisterJob(job_model.LoadFilesystemTask, LoadAtPath, task.Options{Priority: 999})
 	workerPool.RegisterJob(job_model.ExtractAndEmbedTask, ExtractAndEmbedFile)
 }

--- a/services/jobs/jobs.go
+++ b/services/jobs/jobs.go
@@ -90,14 +90,14 @@ func GatherFilesystemStats(tsk *task.Task) {
 
 // RegisterJobs registers all available job handlers with the worker pool.
 func RegisterJobs(workerPool *task.WorkerPool) {
-	workerPool.RegisterJob(job_model.ScanDirectoryTask, ScanDirectory, task.Options{Priority: 1})
-	workerPool.RegisterJob(job_model.ScanFileTask, ScanFile, task.Options{Priority: 2})
-	workerPool.RegisterJob(job_model.UploadFilesTask, HandleFileUploads, task.Options{Persistent: true, Unique: true, Priority: 999})
+	workerPool.RegisterJob(job_model.ScanDirectoryTask, ScanDirectory, task.Options{Priority: task.PriorityLow})
+	workerPool.RegisterJob(job_model.ScanFileTask, ScanFile, task.Options{Priority: task.PriorityMedium})
+	workerPool.RegisterJob(job_model.UploadFilesTask, HandleFileUploads, task.Options{Persistent: true, Unique: true, Priority: task.PriorityHigh})
 	workerPool.RegisterJob(job_model.CreateZipTask, CreateZip, task.Options{Persistent: true, Unique: false})
 	workerPool.RegisterJob(job_model.GatherFsStatsTask, GatherFilesystemStats)
 	workerPool.RegisterJob(job_model.BackupTask, DoBackup)
 	workerPool.RegisterJob(job_model.CopyFileFromCoreTask, CopyFileFromCore)
 	workerPool.RegisterJob(job_model.RestoreCoreTask, RestoreCore)
-	workerPool.RegisterJob(job_model.LoadFilesystemTask, LoadAtPath, task.Options{Priority: 999})
+	workerPool.RegisterJob(job_model.LoadFilesystemTask, LoadAtPath, task.Options{Priority: task.PriorityHigh})
 	workerPool.RegisterJob(job_model.ExtractAndEmbedTask, ExtractAndEmbedFile)
 }

--- a/weblens-vue/weblens-nuxt/components/atom/WeblensButton.vue
+++ b/weblens-vue/weblens-nuxt/components/atom/WeblensButton.vue
@@ -20,7 +20,7 @@
     >
         <slot />
         <span
-            v-if="textContent && !justIcon"
+            v-if="textContent && !justIcon && textWidth !== '0px'"
             :class="{
                 'mx-1 text-nowrap transition-[width]': true,
             }"
@@ -94,6 +94,10 @@ const textContent = computed(() => {
     }
 
     return ''
+})
+
+watchEffect(() => {
+    console.log('text', textContent.value, 'text width', textWidth.value, 'button width', buttonSize.width.value)
 })
 
 async function handleClick(e: MouseEvent) {

--- a/weblens-vue/weblens-nuxt/components/atom/WeblensButton.vue
+++ b/weblens-vue/weblens-nuxt/components/atom/WeblensButton.vue
@@ -96,10 +96,6 @@ const textContent = computed(() => {
     return ''
 })
 
-watchEffect(() => {
-    console.log('text', textContent.value, 'text width', textWidth.value, 'button width', buttonSize.width.value)
-})
-
 async function handleClick(e: MouseEvent) {
     if (!onClick) {
         return

--- a/weblens-vue/weblens-nuxt/pages/settings/dev.vue
+++ b/weblens-vue/weblens-nuxt/pages/settings/dev.vue
@@ -43,6 +43,7 @@
                     'flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs': true,
                     'border-green-700 bg-green-900/40 text-green-300': embedAvailable,
                     'border-red-700 bg-red-900/40 text-red-300': !embedAvailable,
+                    'opacity-50 select-none': !featureFlags?.['embed.processing_enabled'],
                 }"
                 :title="embedAvailable ? 'Embed service reachable' : 'Embed service unavailable'"
             >

--- a/weblens-vue/weblens-nuxt/util/tasks.ts
+++ b/weblens-vue/weblens-nuxt/util/tasks.ts
@@ -59,6 +59,13 @@ export function flattenVisible(roots: TaskTreeNode[], expanded: Set<string>): Vi
             if (seen.has(node.task.taskID)) {
                 continue
             }
+
+            // Don't display a node's children if it's still in the queue, even if it's expanded. This
+            // prevents the page from trying to render possibly hundreds of child rows that don't provide much value.
+            if (depth > 0 && node.task.State === 'InQueue') {
+                continue
+            }
+
             seen.add(node.task.taskID)
 
             rows.push({

--- a/weblens-vue/weblens-nuxt/util/tasks.ts
+++ b/weblens-vue/weblens-nuxt/util/tasks.ts
@@ -60,8 +60,8 @@ export function flattenVisible(roots: TaskTreeNode[], expanded: Set<string>): Vi
                 continue
             }
 
-            // Don't display a node's children if it's still in the queue, even if it's expanded. This
-            // prevents the page from trying to render possibly hundreds of child rows that don't provide much value.
+            // Skip queued descendant nodes (and with them their subtrees) entirely. This prevents the
+            // page from trying to render possibly hundreds of child rows that don't provide much value.
             if (depth > 0 && node.task.State === 'InQueue') {
                 continue
             }


### PR DESCRIPTION
Change backing structure of task scheduling system from a channel to an ordered array of tasks. This array is sorted by task priority, which is derived from the job priority, which is hard coded in `services/jobs/jobs.go`. Tasks with higher priority will be added to the front of the array, and will be popped off first to be executed by the task scheduler. A priority of 0 means "unspecified" and is resolved to `PriorityDefault` when the job is registered; `PriorityLow` (background scans) is the lowest priority currently in use.

This allows for future expansion of the tasks system, like the upcoming split of the scan_file task into two: thumbnail generation and semantic embedding tasks. In that case, thumbnail generation should be prioritized, even if queued after an embedding task.